### PR TITLE
Added a property to Signal to get a masked FFT/frequency array.

### DIFF
--- a/spectral/data/signal.py
+++ b/spectral/data/signal.py
@@ -17,11 +17,20 @@ class Signal:
 
         self.fft = fft(samples)
         self.frequencies = fftfreq(len(self), 1 / self.sample_rate)
+        self._fft_mask = self.frequencies >= 0
 
     @staticmethod
     def generate(sample_rate: int, samples: int, frequency: float, amplitude: float, method=np.sin):
         samples = amplitude * method(2 * np.pi * frequency * np.linspace(0, samples / sample_rate, samples))
         return Signal(sample_rate, samples)
+
+    @property
+    def masked_fft(self):
+        return self.fft[self._fft_mask]
+
+    @property
+    def masked_frequencies(self):
+        return self.frequencies[self._fft_mask]
 
     def __len__(self):
         return len(self.samples)
@@ -53,7 +62,7 @@ class Signal:
     def power(self, frequency: float, df: float):
         interval = (self.frequencies > frequency - df) & (self.frequencies < frequency + df) & (self.frequencies > 0)
         normalized_fft = self.fft / len(self)
-        return integral(self.frequencies[interval], abs(normalized_fft[interval] ** 2))
+        return integral(self.frequencies[interval], np.abs(normalized_fft[interval] ** 2))
 
 
 class ArtificialSignal(Signal):

--- a/test/data/test_signal.py
+++ b/test/data/test_signal.py
@@ -42,6 +42,15 @@ class TestSignalFFT(unittest.TestCase):
         expected_value = self.amplitude
         self.assertAlmostEqual(expected_value, self.signal.power(self.frequency, 2), delta=0.5)
 
+    def test_masked_minimum_zero(self):
+        self.assertEqual(np.min(self.signal.masked_frequencies), 0)
+
+    def test_masked_length(self):
+        expected_length = len(self.signal.fft) // 2
+
+        self.assertEqual(len(self.signal.masked_fft), expected_length)
+        self.assertEqual(len(self.signal.masked_frequencies), expected_length)
+
 
 class TestSignalMultiplication(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Allows you to easily get the FFT/frequency array of a signal with only the positive (and 0) frequency. Useful when plotting par example.