### PR TITLE
Signal division

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,7 +211,7 @@ celerybeat.pid
 .env
 .venv
 env/
-venv/
+venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/.idea/SpectrumAnalyzer.iml
+++ b/.idea/SpectrumAnalyzer.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.8 (venv)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.8 (SpectrumAnalyzer)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/specc/data/signal.py
+++ b/specc/data/signal.py
@@ -105,6 +105,18 @@ class Signal:
     def __rmul__(self, other):
         return self.__mul__(other)
 
+    def __truediv__(self, other):
+        if isinstance(other, (np.ndarray, int, float)):
+            return Signal(self.sample_rate, self.samples / other)
+        else:
+            raise NotImplementedError
+
+    def __rtruediv__(self, other):
+        if isinstance(other, (np.ndarray, int, float)):
+            return Signal(self.sample_rate, other / self.samples)
+        else:
+            raise NotImplementedError
+
     def find_nearest_frequency_index(self, frequency: float) -> int:
         return find_nearest_index(self.frequencies, frequency)
 

--- a/tests/data/test_signal.py
+++ b/tests/data/test_signal.py
@@ -130,6 +130,23 @@ class TestSignalMultiplication(unittest.TestCase):
         self.assertTrue(amplified_signal == expected_signal)
 
 
+class TestSignalDivision(unittest.TestCase):
+    def setUp(self):
+        self.signal = TEST_SIGNAL
+        self.denominator = 2
+
+    def test_dividing_signal_type(self):
+        modified_signal = self.signal / self.denominator
+
+        self.assertTrue(isinstance(modified_signal, Signal), "Dividing Signal by float did not yield a Signal.")
+
+    def test_dividing_signal_values(self):
+        reduced_signal = self.signal / self.denominator
+        expected_signal = Signal(TEST_SAMPLE_RATE, self.signal.samples / self.denominator)
+
+        self.assertTrue(reduced_signal == expected_signal)
+
+
 class TestSaveSignalToFile(unittest.TestCase):
     def setUp(self):
         self.temporary_directory = tempfile.mkdtemp()


### PR DESCRIPTION
Allows to divide signals by an int or float. Also works the other way around (beware of DivisionByZero errors however).